### PR TITLE
gave 'write' the correct number of args in the argc field

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -83,6 +83,6 @@
 {.name="parameters",          .type=func, .rets=true, .ret=list},
 {.name="input",               .type=func, .rets=true, .ret=string},
 {.name="read",                .type=func, .argc=1, .args={string}, .rets=true, .ret=string},
-{.name="write",               .type=func, .argc=1, .args={string,any}},
+{.name="write",               .type=func, .argc=2, .args={string,any}},
 {.name="path",                .type=func, .rets=true, .ret=string},
 #endif

--- a/tests/lists.cog
+++ b/tests/lists.cog
@@ -52,4 +52,3 @@ Print If == 4 Index 3 of List (1 2 3 4 5)
 Print If == 3 Length of List (1 2 3) 
 	"PASS: Getting length of list"
 	"FAIL: Getting length of list";
-	


### PR DESCRIPTION
`write`'s `.argc` had the value 1, which means it takes in one arg, but the signature said otherwise, and it gave a nasty error. 