### PR TITLE
use 'Clear' instead of  'Drop' in rpn.cog

### DIFF
--- a/examples/rpn.cog
+++ b/examples/rpn.cog
@@ -55,5 +55,5 @@ While (/= "done" Twin)
     Eval;
     Put "> "; Input;
 );
-Drop;
+Clear;
 Print "Bye!";


### PR DESCRIPTION
So you can stop the program without an error telling you have some n objects still on the stack.